### PR TITLE
Adjust APIs to filter on assets when lovelace is provided

### DIFF
--- a/src/dex/api/minswap-api.ts
+++ b/src/dex/api/minswap-api.ts
@@ -25,7 +25,7 @@ export class MinswapApi extends BaseApi {
         const maxPerPage: number = 20;
 
         const getPaginatedResponse = (page: number): Promise<LiquidityPool[]> => {
-            return this.api.post(``, {
+            return this.api.post(`?PoolsByAsset`, {
                 operationName: 'PoolsByAsset',
                 query: `
                     query PoolsByAsset($asset: InputAsset!, $limit: Int, $offset: Int) {

--- a/src/dex/api/sundaeswap-api.ts
+++ b/src/dex/api/sundaeswap-api.ts
@@ -24,11 +24,11 @@ export class SundaeSwapApi extends BaseApi {
         const maxPerPage: number = 100;
 
         const assetAId: string = (assetA === 'lovelace')
-            ? ''
+            ? 'cardano.ada'
             : assetA.id('.');
         const assetBId: string = (assetB && assetB !== 'lovelace')
             ? assetB.id('.')
-            : '';
+            : 'cardano.ada';
 
         const getPaginatedResponse = (page: number): Promise<LiquidityPool[]> => {
             return this.api.post('', {

--- a/src/dex/api/vyfinance-api.ts
+++ b/src/dex/api/vyfinance-api.ts
@@ -35,10 +35,11 @@ export class VyfinanceApi extends BaseApi {
                         : 'lovelace';
 
                     // Filtering for supplied assets
-                    const isWanted: boolean = tokensMatch(tokenA, assetA)
-                        || tokensMatch(tokenB, assetA)
-                        || (assetB ? tokensMatch(tokenA, assetB) : false)
-                        || (assetB ? tokensMatch(tokenB, assetB) : false)
+                    let isWanted: boolean = tokensMatch(tokenA, assetA) || tokensMatch(tokenB, assetA);
+
+                    if (assetB) {
+                        isWanted = isWanted && (tokensMatch(tokenA, assetB) || tokensMatch(tokenB, assetB));
+                    }
 
                     if (! isWanted) {
                         return undefined;

--- a/src/dex/api/wingriders-api.ts
+++ b/src/dex/api/wingriders-api.ts
@@ -65,10 +65,11 @@ export class WingRidersApi extends BaseApi {
                     : 'lovelace';
 
                 // Filtering for supplied assets
-                const isWanted: boolean = tokensMatch(tokenA, assetA)
-                    || tokensMatch(tokenB, assetA)
-                    || (assetB ? tokensMatch(tokenA, assetB) : false)
-                    || (assetB ? tokensMatch(tokenB, assetB) : false)
+                let isWanted: boolean = tokensMatch(tokenA, assetA) || tokensMatch(tokenB, assetA);
+
+                if (assetB) {
+                    isWanted = isWanted && (tokensMatch(tokenA, assetB) || tokensMatch(tokenB, assetB));
+                }
 
                 if (! isWanted) {
                     return undefined;


### PR DESCRIPTION
Minswap API has strict limits, so you still might have an issue grabbing pools from there. Still looking into other endpoints that could be less spammy when grabbing pools by providing lovelace as the first asset