### PR TITLE
Spectrum Dex Provider Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 ### What You Can Do
 - Pull Liquidity Pools from DEX APIs or On-chain using [Blockfrost](https://blockfrost.io/) / [Kupo](https://github.com/CardanoSolutions/kupo)
 - Submit and cancel swap orders
+- Submit split swap orders across multple DEXs
 - Build your own data, wallet, or asset metadata providers to plug into Dexter
 - Build swap datums given specific parameters using Dexters _Definition Builder_
 - Load wallets using a seedphrase or CIP-30 interface using [Lucid](https://github.com/spacebudz/lucid)
@@ -207,6 +208,7 @@ dexter.newCancelSwapRequest()
 - [Wallet Providers](https://github.com/IndigoProtocol/dexter/blob/master/docs/providers/wallet.md)
 - [Creating a Fetch Request](https://github.com/IndigoProtocol/dexter/blob/master/docs/requests/fetch-request.md)
 - [Creating a Swap Request](https://github.com/IndigoProtocol/dexter/blob/master/docs/requests/swap-request.md)
+- [Creating a Split Swap Request](https://github.com/IndigoProtocol/dexter/blob/master/docs/requests/split-swap-request.md)
 - [Creating a Cancel Swap Request](https://github.com/IndigoProtocol/dexter/blob/master/docs/requests/cancel-swap-request.md)
 - [Listening for transaction events](https://github.com/IndigoProtocol/dexter/blob/master/docs/dex-transaction.md)
 - [Commonly returned models](https://github.com/IndigoProtocol/dexter/blob/master/docs/models.md)

--- a/src/dex/definitions/spectrum/order.ts
+++ b/src/dex/definitions/spectrum/order.ts
@@ -1,0 +1,69 @@
+import { DatumParameterKey } from '@app/constants';
+
+/**
+ * https://github.com/spectrum-finance/cardano-dex-contracts/blob/master/cardano-dex-contracts-offchain/ErgoDex/Contracts/Proxy/Swap.hs
+ */
+export default {
+  constructor: 0,
+  fields: [
+    {
+      constructor: 0,
+      fields: [
+        {
+          bytes: DatumParameterKey.SwapInTokenPolicyId,
+        },
+        {
+          bytes: DatumParameterKey.SwapInTokenAssetName,
+        },
+      ],
+    },
+    {
+      constructor: 0,
+      fields: [
+        {
+          bytes: DatumParameterKey.SwapOutTokenPolicyId,
+        },
+        {
+          bytes: DatumParameterKey.SwapOutTokenAssetName,
+        },
+      ],
+    },
+    {
+      constructor: 0,
+      fields: [
+        {
+          bytes: DatumParameterKey.TokenPolicyId, // Pool NFT
+        },
+        {
+          bytes: DatumParameterKey.TokenAssetName,
+        },
+      ],
+    },
+    {
+      int: DatumParameterKey.LpFee,
+    },
+    {
+      int: DatumParameterKey.LpFeeNumerator,
+    },
+    {
+      int: DatumParameterKey.LpFeeDenominator,
+    },
+    {
+      bytes: DatumParameterKey.SenderPubKeyHash,
+    },
+    {
+      fields: [
+        {
+          bytes: DatumParameterKey.SenderStakingKeyHash,
+        },
+      ],
+      constructor: 0,
+    },
+    {
+      int: DatumParameterKey.SwapInAmount,
+    },
+    {
+      int: DatumParameterKey.MinReceive,
+    },
+  ],
+};

--- a/src/dex/definitions/spectrum/pool.ts
+++ b/src/dex/definitions/spectrum/pool.ts
@@ -1,0 +1,65 @@
+import { DatumParameterKey } from '@app/constants';
+
+/**
+ * https://github.com/spectrum-finance/cardano-dex-contracts/blob/master/cardano-dex-contracts-offchain/ErgoDex/Contracts/Pool.hs#L48
+ */
+export default {
+  constructor: 0,
+  fields: [
+    {
+      constructor: 0,
+      fields: [
+        {
+          bytes: DatumParameterKey.TokenPolicyId, // Pool NFT
+        },
+        {
+          bytes: DatumParameterKey.TokenAssetName,
+        },
+      ],
+    },
+    {
+      constructor: 0,
+      fields: [
+        {
+          bytes: DatumParameterKey.PoolAssetAPolicyId,
+        },
+        {
+          bytes: DatumParameterKey.PoolAssetAAssetName,
+        },
+      ],
+    },
+    {
+      constructor: 0,
+      fields: [
+        {
+          bytes: DatumParameterKey.PoolAssetBPolicyId,
+        },
+        {
+          bytes: DatumParameterKey.PoolAssetBAssetName,
+        },
+      ],
+    },
+    {
+      constructor: 0,
+      fields: [
+        {
+          bytes: DatumParameterKey.LpTokenPolicyId,
+        },
+        {
+          bytes: DatumParameterKey.LpTokenAssetName,
+        },
+      ],
+    },
+    {
+      int: DatumParameterKey.LpFee,
+    },
+    [
+      {
+        bytes: DatumParameterKey.StakeAdminPolicy,
+      },
+    ],
+    {
+      int: DatumParameterKey.LqBound,
+    },
+  ],
+};

--- a/src/dex/spectrum.ts
+++ b/src/dex/spectrum.ts
@@ -83,7 +83,7 @@ export class Spectrum extends BaseDex {
     return liquidityPool;
   }
 
-  estimatedGive(liquidityPool: LiquidityPool, swapOutToken: Token, swapOutAmount: bigint): bigint {
+  public estimatedGive(liquidityPool: LiquidityPool, swapOutToken: Token, swapOutAmount: bigint): bigint {
     // TODO.
     return 0n;
   }

--- a/src/dex/spectrum.ts
+++ b/src/dex/spectrum.ts
@@ -1,0 +1,211 @@
+import { LiquidityPool } from './models/liquidity-pool';
+import { BaseDataProvider } from '@providers/data/base-data-provider';
+import { Asset, Token } from './models/asset';
+import { BaseDex } from './base-dex';
+import { AssetAddress, AssetBalance, DatumParameters, DefinitionConstr, DefinitionField, PayToAddress, RequestConfig, SwapFee, UTxO } from '@app/types';
+import { DefinitionBuilder } from '@app/definition-builder';
+import { correspondingReserves } from '@app/utils';
+import { AddressType, DatumParameterKey } from '@app/constants';
+import { BaseApi } from '@dex/api/base-api';
+import { Script } from 'lucid-cardano';
+import pool from './definitions/spectrum/pool';
+import order from './definitions/spectrum/order';
+import { all, bignumber, BigNumber, ConfigOptions, create, FormatOptions, MathJsStatic } from 'mathjs';
+
+export class Spectrum extends BaseDex {
+  public static readonly identifier: string = 'Spectrum';
+  public readonly api: BaseApi;
+
+  /**
+   * On-Chain constants.
+   */
+  public readonly orderAddress: string = 'addr1wynp362vmvr8jtc946d3a3utqgclfdl5y9d3kn849e359hsskr20n';
+  public readonly poolAddress: string = 'addr1x8nz307k3sr60gu0e47cmajssy4fmld7u493a4xztjrll0aj764lvrxdayh2ux30fl0ktuh27csgmpevdu89jlxppvrswgxsta';
+
+  constructor(requestConfig: RequestConfig = {}) {
+    super();
+  }
+  public async liquidityPoolAddresses(provider: BaseDataProvider): Promise<string[]> {
+    return Promise.resolve([this.poolAddress]);
+  }
+
+  async liquidityPools(provider: BaseDataProvider): Promise<LiquidityPool[]> {
+    const utxos: UTxO[] = await provider.utxos(this.poolAddress);
+
+    return await Promise.all(
+      utxos.map(async (utxo: UTxO) => {
+        return await this.liquidityPoolFromUtxo(provider, utxo);
+      })
+    ).then((liquidityPools: (LiquidityPool | undefined)[]) => {
+      return liquidityPools.filter((liquidityPool?: LiquidityPool) => {
+        return liquidityPool !== undefined;
+      }) as LiquidityPool[];
+    });
+  }
+
+  public async liquidityPoolFromUtxo(provider: BaseDataProvider, utxo: UTxO): Promise<LiquidityPool | undefined> {
+    if (!utxo.datumHash) {
+      return Promise.resolve(undefined);
+    }
+
+    const relevantAssets = utxo.assetBalances.filter((assetBalance) => {
+      // const assetBalanceId = assetBalance.asset === 'lovelace' ? 'lovelace' : assetBalance.asset.id();
+      const assetName = (assetBalance.asset as Asset).assetName;
+      return !assetName?.toLowerCase()?.endsWith('_nft') && !assetName?.toLowerCase()?.endsWith('_lq');
+    });
+
+    // Irrelevant UTxO
+    if (![2, 3].includes(relevantAssets.length)) {
+      return Promise.resolve(undefined);
+    }
+
+    // Could be ADA/X or X/X pool
+    const assetAIndex: number = relevantAssets.length === 2 ? 0 : 1;
+    const assetBIndex: number = relevantAssets.length === 2 ? 1 : 2;
+
+    const liquidityPool: LiquidityPool = new LiquidityPool(Spectrum.identifier, relevantAssets[assetAIndex].asset, relevantAssets[assetBIndex].asset, relevantAssets[assetAIndex].quantity, relevantAssets[assetBIndex].quantity, utxo.address, this.orderAddress, this.orderAddress);
+
+    // Load additional pool information
+    const lpToken: Asset = utxo.assetBalances.find((assetBalance) => {
+      const assetName = (assetBalance.asset as Asset).assetName;
+      return assetName?.toLowerCase()?.endsWith('_nft');
+    })?.asset as Asset;
+
+    if (lpToken) {
+      lpToken.nameHex = lpToken.nameHex;
+      liquidityPool.lpToken = lpToken;
+    }
+
+    try {
+      const builder: DefinitionBuilder = await new DefinitionBuilder().loadDefinition(pool);
+      const datum: DefinitionField = await provider.datumValue(utxo.datumHash);
+      const parameters: DatumParameters = builder.pullParameters(datum as DefinitionConstr);
+
+      liquidityPool.identifier = typeof parameters.PoolIdentifier === 'string' ? parameters.PoolIdentifier : '';
+      liquidityPool.poolFeePercent = typeof parameters.LpFee === 'number' ? (1000 - parameters.LpFee) / 10 : 0.3;
+    } catch (e) {
+      return liquidityPool;
+    }
+    return liquidityPool;
+  }
+
+  estimatedGive(liquidityPool: LiquidityPool, swapOutToken: Token, swapOutAmount: bigint): bigint {
+    return 0n;
+  }
+
+  public estimatedReceive(liquidityPool: LiquidityPool, swapInToken: Token, swapInAmount: bigint): bigint {
+    return 2n;
+  }
+
+  public priceImpactPercent(liquidityPool: LiquidityPool, swapInToken: Token, swapInAmount: bigint): number {
+    return 0;
+  }
+
+  public buildCancelSwapOrder(): [redeemer: string] {
+    throw new Error('Method not implemented.');
+  }
+
+  public async buildSwapOrder(liquidityPool: LiquidityPool, swapParameters: DatumParameters, spendUtxos: UTxO[] = []): Promise<PayToAddress[]> {
+    const batcherFee: SwapFee | undefined = this.swapOrderFees().find((fee: SwapFee) => fee.id === 'batcherFee');
+    const deposit: SwapFee | undefined = this.swapOrderFees().find((fee: SwapFee) => fee.id === 'deposit');
+    const minReceive = swapParameters.MinReceive as bigint;
+
+    if (!batcherFee || !deposit || !minReceive) {
+      return Promise.reject('Parameters for datum are not set.');
+    }
+
+    const batcherFeeForToken = Number(batcherFee.value) / Number(minReceive);
+    const number = bignumber(batcherFeeForToken.toString());
+    const [numerator, denominator] = decimalToFractional(number);
+
+    const lpfee = 1000 - liquidityPool.poolFeePercent * 10;
+
+    swapParameters = {
+      ...swapParameters,
+      [DatumParameterKey.TokenPolicyId]: liquidityPool.lpToken.policyId,
+      [DatumParameterKey.TokenAssetName]: liquidityPool.lpToken.nameHex,
+      [DatumParameterKey.LpFee]: lpfee,
+      [DatumParameterKey.LpFeeNumerator]: numerator,
+      [DatumParameterKey.LpFeeDenominator]: denominator,
+    };
+
+    const datumBuilder: DefinitionBuilder = new DefinitionBuilder();
+    await datumBuilder.loadDefinition(order).then((builder: DefinitionBuilder) => {
+      builder.pushParameters(swapParameters);
+    });
+
+    return [
+      this.buildSwapOrderPayment(swapParameters, {
+        address: this.orderAddress,
+        addressType: AddressType.Contract,
+        assetBalances: [
+          {
+            asset: 'lovelace',
+            quantity: batcherFee?.value + deposit.value,
+          },
+        ],
+        datum: datumBuilder.getCbor(),
+        spendUtxos: spendUtxos,
+      }),
+    ];
+  }
+
+  public swapOrderFees(): SwapFee[] {
+    const networkFee = 0.5; // 0.5 ADA
+    const reward = 1; // 1 ADA.
+    const minNitro = 1.2;
+    const batcherFee = (reward + networkFee) * minNitro;
+    const batcherFeeInAda = BigInt(Math.round(batcherFee * 10 ** 6));
+    return [
+      {
+        id: 'batcherFee',
+        title: 'Batcher Fee',
+        description: 'Fee paid for the service of off-chain batcher to process transactions.',
+        value: batcherFeeInAda,
+        isReturned: false,
+      },
+      {
+        id: 'deposit',
+        title: 'Deposit',
+        description: 'This amount of ADA will be held as minimum UTxO ADA and will be returned when your order is processed or cancelled.',
+        value: 2_000000n,
+        isReturned: true,
+      },
+    ];
+  }
+}
+
+const mathConf: ConfigOptions = {
+  epsilon: 1e-24,
+  matrix: 'Matrix',
+  number: 'BigNumber',
+  precision: 64,
+};
+
+const formatOptions: FormatOptions = {
+  notation: 'fixed',
+};
+
+export const math = create(all, mathConf) as Partial<MathJsStatic>;
+
+function evaluate(expr: string): string {
+  return math.format!(math.evaluate!(expr), formatOptions);
+}
+
+function decimalToFractional(n: BigNumber | number): [bigint, bigint] {
+  const fmtN = math.format!(n, formatOptions);
+  const [whole, decimals = ''] = String(fmtN).split('.');
+  const numDecimals = decimals.length;
+  const denominator = BigInt(evaluate(`10^${numDecimals}`));
+  const numerator = BigInt(whole) * denominator + BigInt(decimals);
+  return [numerator, denominator];
+}
+
+// WIP to remove the mathjs dependency & configuration logic.
+function decimalToFractionalImproved(decimalValue: bigint | number): [bigint, bigint] {
+  const [whole, decimals = ''] = decimalValue.toString()?.split('.');
+  let truncatedDecimals = decimals.slice(0, 15);
+  const denominator = 10n ** BigInt(truncatedDecimals.length);
+  const numerator = BigInt(whole + truncatedDecimals);
+  return [numerator, denominator];
+}

--- a/src/dexter.ts
+++ b/src/dexter.ts
@@ -12,123 +12,123 @@ import { BaseMetadataProvider } from '@providers/asset-metadata/base-metadata-pr
 import { TokenRegistryProvider } from '@providers/asset-metadata/token-registry-provider';
 import { CancelSwapRequest } from '@requests/cancel-swap-request';
 import { FetchRequest } from '@requests/fetch-request';
-import axios from "axios";
-import axiosRetry from "axios-retry";
+import axios from 'axios';
+import axiosRetry from 'axios-retry';
 import { SplitSwapRequest } from '@requests/split-swap-request';
+import { Spectrum } from './dex/spectrum';
 
 export class Dexter {
+  public config: DexterConfig;
+  public requestConfig: RequestConfig;
 
-    public config: DexterConfig;
-    public requestConfig: RequestConfig;
+  public dataProvider?: BaseDataProvider;
+  public walletProvider?: BaseWalletProvider;
+  public metadataProvider: BaseMetadataProvider;
 
-    public dataProvider?: BaseDataProvider;
-    public walletProvider?: BaseWalletProvider;
-    public metadataProvider: BaseMetadataProvider;
+  public availableDexs: AvailableDexs;
 
-    public availableDexs: AvailableDexs;
+  constructor(config: DexterConfig = {}, requestConfig: RequestConfig = {}) {
+    this.config = Object.assign(
+      {},
+      {
+        shouldFetchMetadata: true,
+        shouldFallbackToApi: true,
+        shouldSubmitOrders: false,
+        metadataMsgBranding: 'Dexter',
+      } as DexterConfig,
+      config
+    );
+    this.requestConfig = Object.assign(
+      {},
+      {
+        timeout: 5000,
+        proxyUrl: '',
+        retries: 3,
+      } as RequestConfig,
+      requestConfig
+    );
 
-    constructor(config: DexterConfig = {}, requestConfig: RequestConfig = {}) {
-        this.config = Object.assign(
-            {},
-            {
-                shouldFetchMetadata: true,
-                shouldFallbackToApi: true,
-                shouldSubmitOrders: false,
-                metadataMsgBranding: 'Dexter',
-            } as DexterConfig,
-            config,
-        );
-        this.requestConfig = Object.assign(
-            {},
-            {
-                timeout: 5000,
-                proxyUrl: '',
-                retries: 3,
-            } as RequestConfig,
-            requestConfig,
-        );
+    // Axios configurations
+    axiosRetry(axios, { retries: this.requestConfig.retries });
+    axios.defaults.timeout = this.requestConfig.timeout;
 
-        // Axios configurations
-        axiosRetry(axios, { retries: this.requestConfig.retries });
-        axios.defaults.timeout = this.requestConfig.timeout;
+    this.metadataProvider = new TokenRegistryProvider(this.requestConfig);
+    this.availableDexs = {
+      [Minswap.identifier]: new Minswap(this.requestConfig),
+      [SundaeSwap.identifier]: new SundaeSwap(this.requestConfig),
+      [MuesliSwap.identifier]: new MuesliSwap(this.requestConfig),
+      [WingRiders.identifier]: new WingRiders(this.requestConfig),
+      [VyFinance.identifier]: new VyFinance(this.requestConfig),
+      [Spectrum.identifier]: new Spectrum(this.requestConfig),
+    };
+  }
 
-        this.metadataProvider = new TokenRegistryProvider(this.requestConfig);
-        this.availableDexs = {
-            [Minswap.identifier]: new Minswap(this.requestConfig),
-            [SundaeSwap.identifier]: new SundaeSwap(this.requestConfig),
-            [MuesliSwap.identifier]: new MuesliSwap(this.requestConfig),
-            [WingRiders.identifier]: new WingRiders(this.requestConfig),
-            [VyFinance.identifier]: new VyFinance(this.requestConfig),
-        };
+  /**
+   * Retrieve DEX instance from unique name.
+   */
+  public dexByName(name: string): BaseDex | undefined {
+    return this.availableDexs[name];
+  }
+
+  /**
+   * Switch to a new data provider.
+   */
+  public withDataProvider(dataProvider: BaseDataProvider): Dexter {
+    this.dataProvider = dataProvider;
+
+    return this;
+  }
+
+  /**
+   * Switch to a new wallet provider.
+   */
+  public withWalletProvider(walletProvider: BaseWalletProvider): Dexter {
+    this.walletProvider = walletProvider;
+
+    return this;
+  }
+
+  /**
+   * Switch to a new asset metadata provider.
+   */
+  public withMetadataProvider(metadataProvider: BaseMetadataProvider): Dexter {
+    this.metadataProvider = metadataProvider;
+
+    return this;
+  }
+
+  /**
+   * New request for data fetching.
+   */
+  public newFetchRequest(): FetchRequest {
+    return new FetchRequest(this);
+  }
+
+  /**
+   * New request for a swap order.
+   */
+  public newSwapRequest(): SwapRequest {
+    return new SwapRequest(this);
+  }
+
+  /**
+   * New request for a split swap order.
+   */
+  public newSplitSwapRequest(): SplitSwapRequest {
+    return new SplitSwapRequest(this);
+  }
+
+  /**
+   * New request for cancelling a swap order.
+   */
+  public newCancelSwapRequest(): CancelSwapRequest {
+    if (!this.walletProvider) {
+      throw new Error('Wallet provider must be set before requesting a cancel order.');
+    }
+    if (!this.walletProvider.isWalletLoaded) {
+      throw new Error('Wallet must be loaded before requesting a cancel order.');
     }
 
-    /**
-     * Retrieve DEX instance from unique name.
-     */
-    public dexByName(name: string): BaseDex | undefined {
-        return this.availableDexs[name];
-    }
-
-    /**
-     * Switch to a new data provider.
-     */
-    public withDataProvider(dataProvider: BaseDataProvider): Dexter {
-        this.dataProvider = dataProvider;
-
-        return this;
-    }
-
-    /**
-     * Switch to a new wallet provider.
-     */
-    public withWalletProvider(walletProvider: BaseWalletProvider): Dexter {
-        this.walletProvider = walletProvider;
-
-        return this;
-    }
-
-    /**
-     * Switch to a new asset metadata provider.
-     */
-    public withMetadataProvider(metadataProvider: BaseMetadataProvider): Dexter {
-        this.metadataProvider = metadataProvider;
-
-        return this;
-    }
-
-    /**
-     * New request for data fetching.
-     */
-    public newFetchRequest(): FetchRequest {
-        return new FetchRequest(this);
-    }
-
-    /**
-     * New request for a swap order.
-     */
-    public newSwapRequest(): SwapRequest {
-        return new SwapRequest(this);
-    }
-
-    /**
-     * New request for a split swap order.
-     */
-    public newSplitSwapRequest(): SplitSwapRequest {
-        return new SplitSwapRequest(this);
-    }
-
-    /**
-     * New request for cancelling a swap order.
-     */
-    public newCancelSwapRequest(): CancelSwapRequest {
-        if (! this.walletProvider) {
-            throw new Error('Wallet provider must be set before requesting a cancel order.');
-        }
-        if (! this.walletProvider.isWalletLoaded) {
-            throw new Error('Wallet must be loaded before requesting a cancel order.');
-        }
-
-        return new CancelSwapRequest(this);
-    }
-
+    return new CancelSwapRequest(this);
+  }
 }

--- a/src/dexter.ts
+++ b/src/dexter.ts
@@ -59,7 +59,7 @@ export class Dexter {
       [MuesliSwap.identifier]: new MuesliSwap(this.requestConfig),
       [WingRiders.identifier]: new WingRiders(this.requestConfig),
       [VyFinance.identifier]: new VyFinance(this.requestConfig),
-      [Spectrum.identifier]: new Spectrum(this.requestConfig),
+      //   [Spectrum.identifier]: new Spectrum(this.requestConfig),
     };
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,144 +1,146 @@
 import { AddressType, DatumParameterKey, TransactionStatus } from './constants';
 import { Token } from '@dex/models/asset';
 import { BaseDex } from '@dex/base-dex';
-import { BaseDataProvider } from '@providers/data/base-data-provider';
 import { LiquidityPool } from '@dex/models/liquidity-pool';
 
 export interface DexterConfig {
-    shouldFetchMetadata?: boolean,
-    shouldFallbackToApi?: boolean,
-    shouldSubmitOrders?: boolean,
-    metadataMsgBranding?: string,
+  shouldFetchMetadata?: boolean;
+  shouldFallbackToApi?: boolean;
+  shouldSubmitOrders?: boolean;
+  metadataMsgBranding?: string;
 }
 
 export interface RequestConfig {
-    timeout?: number,
-    proxyUrl?: string,
-    retries?: number,
+  timeout?: number;
+  proxyUrl?: string;
+  retries?: number;
 }
 
 export interface BlockfrostConfig {
-    url: string,
-    projectId: string,
+  url: string;
+  projectId: string;
 }
 
 export interface KupoConfig {
-    url: string,
+  url: string;
 }
 
 export interface KupmiosConfig {
-    kupoUrl: string,
-    ogmiosUrl: string,
+  kupoUrl: string;
+  ogmiosUrl: string;
 }
 
 export type AvailableDexs = {
-    [dex: string]: BaseDex,
-}
+  [dex: string]: BaseDex;
+};
 
 export type DatumParameters = {
-    [key in DatumParameterKey | string]?: string | number | bigint
-}
+  [key in DatumParameterKey | string]?: string | number | bigint;
+};
 
 export type AssetBalance = {
-    asset: Token,
-    quantity: bigint,
-}
+  asset: Token;
+  quantity: bigint;
+};
 
 export type UTxO = {
-    txHash: string,
-    address: string,
-    datumHash: string,
-    outputIndex: number,
-    assetBalances: AssetBalance[],
+  txHash: string;
+  address: string;
+  datumHash: string;
+  outputIndex: number;
+  assetBalances: AssetBalance[];
 };
 
 export type Transaction = {
-    hash: string,
-    inputs: UTxO[],
-    outputs: UTxO[],
+  hash: string;
+  inputs: UTxO[];
+  outputs: UTxO[];
 };
 
 export type AssetAddress = {
-    address: string,
-    quantity: bigint,
-}
+  address: string;
+  quantity: bigint;
+};
 
 export type DefinitionBytes = {
-    bytes: string | DatumParameterKey,
-}
+  bytes: string | DatumParameterKey;
+};
 
 export type DefinitionInt = {
-    int: number | DatumParameterKey,
-}
+  int: number | DatumParameterKey;
+};
 
-export type DefinitionField = DefinitionConstr | DefinitionBytes | DefinitionInt
+export type DefinitionField = DefinitionConstr | DefinitionBytes | DefinitionBytes[] | DefinitionInt;
 
 export type DefinitionConstr = {
-    constructor: number | DatumParameterKey,
-    fields: DefinitionField[],
-}
+  constructor: number | DatumParameterKey;
+  fields: DefinitionField[];
+};
 
 export type WalletOptions = {
-    addressType?: AddressType,
-    accountIndex?: number,
-}
+  addressType?: AddressType;
+  accountIndex?: number;
+};
 
 export type PayToAddress = {
-    address: string,
-    addressType: AddressType,
-    assetBalances: AssetBalance[],
-    spendUtxos?: UTxO[],
-    datum?: string,
+  address: string;
+  addressType: AddressType;
+  assetBalances: AssetBalance[];
+  spendUtxos?: UTxO[];
+  datum?: string;
 };
 
 export type SwapFee = {
-    id: string,
-    title: string,
-    description: string,
-    value: bigint,
-    isReturned: boolean,
+  id: string;
+  title: string;
+  description: string;
+  value: bigint;
+  isReturned: boolean;
 };
 
 export type SwapInAmountMapping = {
-    swapInAmount: bigint,
-    liquidityPool: LiquidityPool,
-}
+  swapInAmount: bigint;
+  liquidityPool: LiquidityPool;
+};
 
 export type SwapOutAmountMapping = {
-    swapOutAmount: bigint,
-    liquidityPool: LiquidityPool,
-}
+  swapOutAmount: bigint;
+  liquidityPool: LiquidityPool;
+};
 
 export type DexTransactionError = {
-    step: TransactionStatus,
-    reason: string,
-    reasonRaw: string,
+  step: TransactionStatus;
+  reason: string;
+  reasonRaw: string;
 };
 
 export type AssetMetadata = {
-    policyId: string,
-    nameHex: string,
-    decimals: number,
+  policyId: string;
+  nameHex: string;
+  decimals: number;
 };
 
 export type Cip30Api = {
-    getNetworkId(): Promise<number>;
-    getUtxos(): Promise<string[] | undefined>;
-    getBalance(): Promise<string>;
-    getUsedAddresses(): Promise<string[]>;
-    getUnusedAddresses(): Promise<string[]>;
-    getChangeAddress(): Promise<string>;
-    getRewardAddresses(): Promise<string[]>;
-    signTx(tx: string, partialSign: boolean): Promise<string>;
-    signData(address: string, payload: string): Promise<{
-        signature: string;
-        key: string;
-    }>;
-    submitTx(tx: string): Promise<string>;
+  getNetworkId(): Promise<number>;
+  getUtxos(): Promise<string[] | undefined>;
+  getBalance(): Promise<string>;
+  getUsedAddresses(): Promise<string[]>;
+  getUnusedAddresses(): Promise<string[]>;
+  getChangeAddress(): Promise<string>;
+  getRewardAddresses(): Promise<string[]>;
+  signTx(tx: string, partialSign: boolean): Promise<string>;
+  signData(
+    address: string,
+    payload: string
+  ): Promise<{
+    signature: string;
+    key: string;
+  }>;
+  submitTx(tx: string): Promise<string>;
+  getCollateral(): Promise<string[]>;
+  experimental: {
     getCollateral(): Promise<string[]>;
-    experimental: {
-        getCollateral(): Promise<string[]>;
-        on(eventName: string, callback: (...args: unknown[]) => void): void;
-        off(eventName: string, callback: (...args: unknown[]) => void): void;
-    };
+    on(eventName: string, callback: (...args: unknown[]) => void): void;
+    off(eventName: string, callback: (...args: unknown[]) => void): void;
+  };
 };


### PR DESCRIPTION
I wanted to commit the code I currently have for integrating Spectrum, to reduce duplicated effort & allow collaboration. 🚀 

- Initial Spectrum Implementation with on-chain pool identification & swap order support logic. 🤝 

Notes:
- I've created a `decimalToFractionalImproved` method in hope to reduce the coupled dependencies of mathjs when ported from their SDK.
- estimatedGive, estimatedReceive & priceImpactPercent need calculation logic implementing.

Important:
Spectrum uses the plutus v2, inline datum feature, if we use this on any v1 implementation it makes it impossible to retrieve the assets, I've left this out of the `payToContract` for this reason, just an idea but it might be worth us splitting out the method on this to limit risk.