### PR TITLE
fix: on fetch-request the uuid comparison fails

### DIFF
--- a/src/dex/models/liquidity-pool.ts
+++ b/src/dex/models/liquidity-pool.ts
@@ -16,7 +16,7 @@ export class LiquidityPool {
     poolFeePercent: number = 0;
     extra: any = {};
 
-    constructor(dex: string, assetA: Token, assetB: Token, reserveA: bigint, reserveB: bigint, address: string, marketOrderAddress: string = '', limitOrderAddress: string = '') {
+    constructor(dex: string, assetA: Token, assetB: Token, reserveA: bigint, reserveB: bigint, address: string, marketOrderAddress: string = '', limitOrderAddress: string = '', identifier: string = '') {
         this.dex = dex;
         this.assetA = assetA;
         this.assetB = assetB;
@@ -25,6 +25,7 @@ export class LiquidityPool {
         this.address = address;
         this.marketOrderAddress = marketOrderAddress;
         this.limitOrderAddress = limitOrderAddress;
+        this.identifier = identifier;
     }
 
     get uuid(): string {


### PR DESCRIPTION
On LiquidityPool class identifier is always empty, which caused the following request to fail because `return pool !== undefined && pool.uuid === liquidityPool.uuid;` always false on fetch-request.

```typescript
  const liquidityPool = new LiquidityPool(
    Minswap.identifier,
    "lovelace",
    asset,
    5126788000507n,
    1405674367646n,
    'script1uychk9f04tqngfhx4qlqdlug5ntzen3uzc62kzj7cyesjk0d9me'
  );
  const updatedLiquidityPool = await DexterManager.dexter
    .newFetchRequest()
    .getLiquidityPoolState(liquidityPool);
```