### PR TITLE
Dexter/cancel orders tests

### DIFF
--- a/tests/minswap.test.ts
+++ b/tests/minswap.test.ts
@@ -9,11 +9,10 @@ import {
     DatumParameters,
     DatumParameterKey,
     PayToAddress,
-    AddressType
-} from '../src';
-import {
+    AddressType,
     UTxO
-} from '@app/types';
+} from '../src';
+
 describe('Minswap', () => {
     let minswap: Minswap;
     const returnAddress = 'mockBlockchainAddress123';

--- a/tests/minswap.test.ts
+++ b/tests/minswap.test.ts
@@ -102,7 +102,7 @@ describe('Minswap', () => {
 
     });
 
-    describe('Minswap Cancel Order Flow', () => {
+    describe('Minswap Cancel Order', () => {
 
         it('should successfully cancel an order', async () => {
             let marketOrderAddress = minswap.marketOrderAddress;

--- a/tests/minswap.test.ts
+++ b/tests/minswap.test.ts
@@ -11,15 +11,23 @@ import {
     PayToAddress,
     AddressType
 } from '../src';
-
+import {
+    UTxO
+} from '@app/types';
 describe('Minswap', () => {
+    let minswap: Minswap;
+    const returnAddress = 'mockBlockchainAddress123';
 
+    beforeEach(() => {
+        minswap = new Minswap();
+    });
     const walletProvider: MockWalletProvider = new MockWalletProvider();
     walletProvider.loadWalletFromSeedPhrase(['']);
     const dexter: Dexter = (new Dexter())
         .withDataProvider(new MockDataProvider())
         .withWalletProvider(walletProvider);
     const asset: Asset = new Asset('f66d78b4a3cb3d37afa0ec36461e51ecbde00f26c8f0a68f94b69880', '69555344', 6);
+
 
     describe('Set Swap In', () => {
 
@@ -92,6 +100,49 @@ describe('Minswap', () => {
             expect(swapRequest.swapInAmount).toEqual(365844367n);
         });
 
+    });
+
+    describe('Minswap Cancel Order Flow', () => {
+
+        it('should successfully cancel an order', async () => {
+            let marketOrderAddress = minswap.marketOrderAddress;
+            const txOutputs: UTxO[] = [
+                {
+                    txHash: 'mockTxHash123',
+                    address: marketOrderAddress,
+                    datumHash: 'mockDatumHash123',
+                    outputIndex: 0,
+                    assetBalances: [{ asset: 'lovelace', quantity: 1000000000000n }]
+                }
+            ];
+
+            const result = await minswap.buildCancelSwapOrder(txOutputs, returnAddress);
+
+            expect(result).toBeDefined();
+            expect(result[0].address).toBe(returnAddress);
+        });
+
+        it('should fail to cancel an order with invalid UTxO', async () => {
+            const invalidTxOutputs: UTxO[] = [
+                {
+                    txHash: 'invalidTxHash',
+                    address: 'invalidAddress',
+                    datumHash: 'invalidDatumHash',
+                    outputIndex: 0,
+                    assetBalances: [{ asset: 'lovelace', quantity: 1000n }]
+                }
+            ];
+
+
+            try {
+                await minswap.buildCancelSwapOrder(invalidTxOutputs, returnAddress);
+                fail('Expected buildCancelSwapOrder to throw an error');
+            } catch (error: unknown) {
+                if (error instanceof Error) {
+                    expect(error.message).toContain('Unable to find relevant UTxO for cancelling the swap order.');
+                }
+            }
+        });
     });
 
 });

--- a/tests/muesliswap.test.ts
+++ b/tests/muesliswap.test.ts
@@ -95,7 +95,7 @@ describe('MuesliSwap', () => {
 
     });
 
-    describe('Muesliswap Cancel Order FLow', () => {
+    describe('Muesliswap Cancel Order', () => {
         let muesliswap: MuesliSwap;
         const returnAddress = 'mockBlockchainAddress123';
 

--- a/tests/muesliswap.test.ts
+++ b/tests/muesliswap.test.ts
@@ -10,8 +10,8 @@ import {
     DatumParameterKey,
     PayToAddress,
     AddressType,
+    UTxO
 } from '../src';
-import {UTxO} from "@app/types";
 
 describe('MuesliSwap', () => {
 

--- a/tests/muesliswap.test.ts
+++ b/tests/muesliswap.test.ts
@@ -11,6 +11,7 @@ import {
     PayToAddress,
     AddressType,
 } from '../src';
+import {UTxO} from "@app/types";
 
 describe('MuesliSwap', () => {
 
@@ -90,6 +91,55 @@ describe('MuesliSwap', () => {
 
         it('Can calculate swap parameters', () => {
             expect(swapRequest.swapInAmount).toEqual(133971309n);
+        });
+
+    });
+
+    describe('Muesliswap Cancel Order FLow', () => {
+        let muesliswap: MuesliSwap;
+        const returnAddress = 'mockBlockchainAddress123';
+
+        beforeEach(() => {
+            muesliswap = new MuesliSwap();
+        });
+
+        it('should successfully cancel an order', async () => {
+            let orderAddress = muesliswap.orderAddress;
+            const txOutputs: UTxO[] = [
+                {
+                    txHash: 'mockTxHash123',
+                    address: orderAddress,
+                    datumHash: 'mockDatumHash123',
+                    outputIndex: 0,
+                    assetBalances: [{ asset: 'lovelace', quantity: 10000n }]
+                }
+            ];
+
+            const result = await muesliswap.buildCancelSwapOrder(txOutputs, returnAddress);
+
+            expect(result).toBeDefined();
+            expect(result[0].address).toBe(returnAddress);
+        });
+
+        it('should fail to cancel an order with invalid UTxO', async () => {
+            const invalidTxOutputs: UTxO[] = [
+                {
+                    txHash: 'invalidTxHash',
+                    address: 'invalidAddress',
+                    datumHash: 'invalidDatumHash',
+                    outputIndex: 0,
+                    assetBalances: [{ asset: 'lovelace', quantity: 10000n }]
+                }
+            ];
+
+            try {
+                await muesliswap.buildCancelSwapOrder(invalidTxOutputs, returnAddress);
+                fail('Expected buildCancelSwapOrder to throw an error');
+            } catch (error: unknown) {
+                if (error instanceof Error) {
+                    expect(error.message).toContain('Unable to find relevant UTxO for cancelling the swap order.');
+                }
+            }
         });
 
     });

--- a/tests/spectrum.test.ts
+++ b/tests/spectrum.test.ts
@@ -8,9 +8,10 @@ import {
     DatumParameters,
     DatumParameterKey,
     PayToAddress,
-    AddressType, UTxO,
+    AddressType,
+    UTxO,
+    Spectrum
 } from '../src';
-import { Spectrum } from '../src';
 
 describe('Spectrum', () => {
 

--- a/tests/spectrum.test.ts
+++ b/tests/spectrum.test.ts
@@ -8,7 +8,7 @@ import {
     DatumParameters,
     DatumParameterKey,
     PayToAddress,
-    AddressType, MuesliSwap, UTxO,
+    AddressType, UTxO,
 } from '../src';
 import { Spectrum } from '../src';
 

--- a/tests/teddyswap.test.ts
+++ b/tests/teddyswap.test.ts
@@ -9,7 +9,7 @@ import {
     DatumParameterKey,
     PayToAddress,
     AddressType,
-    TeddySwap,
+    TeddySwap, UTxO,
 } from '../src';
 
 describe('TeddySwap', () => {
@@ -95,6 +95,55 @@ describe('TeddySwap', () => {
         it('Can calculate swap parameters', () => {
             expect(swapRequest.swapInAmount).toEqual(7950789864n);
         });
+
+    });
+
+    describe('Teddyswap Cancel Order', () => {
+        let teddyswap: TeddySwap;
+        const returnAddress = 'addr1';
+        beforeEach(() => {
+            teddyswap = new TeddySwap();
+        });
+
+        it('should successfully cancel an order', async () => {
+            let marketOrderAddress = teddyswap.orderAddress;
+            const txOutputs: UTxO[] = [
+                {
+                    txHash: 'mockTxHash123',
+                    address: marketOrderAddress,
+                    datumHash: 'mockDatumHash123',
+                    outputIndex: 0,
+                    assetBalances: [{ asset: 'lovelace', quantity: 1000000000000n }]
+                }
+            ];
+
+            const result = await teddyswap.buildCancelSwapOrder(txOutputs, returnAddress);
+
+            expect(result).toBeDefined();
+            expect(result[0].address).toBe(returnAddress);
+        });
+
+        it('should fail to cancel an order with invalid UTxO', async () => {
+            const invalidTxOutputs: UTxO[] = [
+                {
+                    txHash: 'invalidTxHash',
+                    address: 'invalidAddress',
+                    datumHash: 'invalidDatumHash',
+                    outputIndex: 0,
+                    assetBalances: [{ asset: 'lovelace', quantity: 1000000000000n }]
+                }
+            ];
+            try {
+                await teddyswap.buildCancelSwapOrder(invalidTxOutputs, returnAddress);
+                fail('Expected buildCancelSwapOrder to throw an error');
+            } catch (error: unknown) {
+                if (error instanceof Error) {
+                    expect(error.message).toContain('Unable to find relevant UTxO for cancelling the swap order.');
+                }
+            }
+
+        });
+
 
     });
 


### PR DESCRIPTION
dexter/cancel-order-tests

TESTS for:
- minswap cancel order
- muesliSwap cancel order
- spectrum cancel order
- teddySwap cancel order
- vyFinance cancel order
- wingRiders cancel order
- sundaeSwap cancel order